### PR TITLE
Strict samesite cookie policy

### DIFF
--- a/cms/index.php
+++ b/cms/index.php
@@ -33,6 +33,7 @@
 
 try
  {
+  ini_set('session.cookie_samesite','Strict');
   session_start();
   define('IN_INDEX', TRUE);
   #include('./config/db_settings.conf.php');

--- a/index.php
+++ b/index.php
@@ -31,6 +31,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+ini_set('session.cookie_samesite','Strict');
 session_start();
 
 define('CACHE_DIR', 'cms/cache/');


### PR DESCRIPTION
This CMS is expected to be used by small standalone webpages, hence strict samesite cookie policy is a good idea as an additional fence against cross site request forgery attacks. (see for example old vulnerability at https://www.exploit-db.com/exploits/37588 )